### PR TITLE
No renderizar plantilla index

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ var router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
+  // No se debería manejar esta ruta renderizando una plantilla.
   res.render('index', { title: 'Express' });
 });
 


### PR DESCRIPTION
No se debería manejar la ruta principal renderizando una plantilla.